### PR TITLE
Bug Fixes for zeros due to Mapping

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,8 @@
  * @param {Array} argV - arguments given in the command line to parse
  * @returns - String representation of each digit
  */
- var NumToString = function(argV) {
+ var NumToString = function(arguments) {
+    argV = arguments.map(Number);
     var result = [];
     // Error handling no inputs
     if(argV.length == 0){
@@ -17,7 +18,7 @@
             console.log("Error in input. Please enter valid postive numbers");
             return;
         }
-        let sNumber = argV[i].toString();
+        let sNumber = arguments[i];
         for (let j = 0; j < sNumber.length; j++) {
             currString += numbers[sNumber.charAt(j)];
         }
@@ -27,6 +28,5 @@
 };
 // Main
 var numbers = ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"];
-var args = process.argv.slice(2);
-args = args.map(Number);
+let args = process.argv.slice(2);
 NumToString(args);


### PR DESCRIPTION
When a user types "000" it would only display "Zero" this is a bug and needed fixing via changing the way the argument array is mapped.